### PR TITLE
Fix bugs from switching to d3v3

### DIFF
--- a/sunburst.js
+++ b/sunburst.js
@@ -301,7 +301,7 @@
 			.text(function(d) { return d.data.name; });
 
 		// Set position for entering and updating nodes.
-		g.attr("transform", function(d, i) {
+		entering.attr("transform", function(d, i) {
 			return "translate(" + i * (b.w + b.s) + ", 0)";
 		});
 

--- a/sunburst.js
+++ b/sunburst.js
@@ -345,14 +345,14 @@
 			.attr("ry", li.r)
 			.attr("width", li.w)
 			.attr("height", li.h)
-			.style("fill", function(d) { return d.value; });
+			.style("fill", function(d) { return d[1]; });
 
 		g.append("svg:text")
 			.attr("x", li.w / 2)
 			.attr("y", li.h / 2)
 			.attr("dy", "0.35em")
 			.attr("text-anchor", "middle")
-			.text(function(d) { return d.key; });
+			.text(function(d) { return d[0]; });
 	}
 
 	// Take a 2-column CSV and transform it into a hierarchical structure suitable


### PR DESCRIPTION
I addressed the new behaviors of data joining (enter/update/exit) and switching from `d3.entries()` to `Object.entries()`. This should fix #11 and, hopefully, #10 . 